### PR TITLE
⬆️ Bump mozjpeg version to 0.10

### DIFF
--- a/nokhwa-core/Cargo.toml
+++ b/nokhwa-core/Cargo.toml
@@ -42,7 +42,7 @@ default-features = false
 optional = true
 
 [dependencies.mozjpeg]
-version = "0.9"
+version = "0.10"
 optional = true
 
 [package.metadata.docs.rs]

--- a/nokhwa-core/src/types.rs
+++ b/nokhwa-core/src/types.rs
@@ -1501,9 +1501,9 @@ pub fn mjpeg_to_rgb(data: &[u8], rgba: bool) -> Result<Vec<u8>, NokhwaError> {
         }
     };
 
-    let scanlines_res: Option<Vec<u8>> = jpeg_decompress.read_scanlines_flat();
+    let scanlines_res = jpeg_decompress.read_scanlines();
     // assert!(jpeg_decompress.finish_decompress());
-    if !jpeg_decompress.finish_decompress() {
+    if !jpeg_decompress.finish().is_err() {
         return Err(NokhwaError::ProcessFrameError {
             src: FrameFormat::MJPEG,
             destination: "RGB888".to_string(),
@@ -1512,8 +1512,8 @@ pub fn mjpeg_to_rgb(data: &[u8], rgba: bool) -> Result<Vec<u8>, NokhwaError> {
     }
 
     match scanlines_res {
-        Some(pixels) => Ok(pixels),
-        None => Err(NokhwaError::ProcessFrameError {
+        Ok(pixels) => Ok(pixels),
+        Err(_) => Err(NokhwaError::ProcessFrameError {
             src: FrameFormat::MJPEG,
             destination: "RGB888".to_string(),
             error: "Failed to get read readlines into RGB888 pixels!".to_string(),
@@ -1573,9 +1573,9 @@ pub fn buf_mjpeg_to_rgb(data: &[u8], dest: &mut [u8], rgba: bool) -> Result<(), 
         });
     }
 
-    jpeg_decompress.read_scanlines_flat_into(dest);
+    let r = jpeg_decompress.read_scanlines_into(dest);
     // assert!(jpeg_decompress.finish_decompress());
-    if !jpeg_decompress.finish_decompress() {
+    if !jpeg_decompress.finish().is_err() {
         return Err(NokhwaError::ProcessFrameError {
             src: FrameFormat::MJPEG,
             destination: "RGB888".to_string(),


### PR DESCRIPTION
0.9 does not work anymore as mozjpeg-sys 1.* were deleted from crates.io